### PR TITLE
http: normalize path parameter decoding

### DIFF
--- a/.agents/skills/loom/SKILL.md
+++ b/.agents/skills/loom/SKILL.md
@@ -125,6 +125,11 @@ build Auto-K without repeating large amounts of app-local glue.
   If the DSL field also has `Format(...)`, generated HTTP decoders do not emit
   a second string format check; the custom Go type owns parse/format
   validation.
+- Generated HTTP path constructors pass decoded scalar and array values to
+  `url.URL.Path`, which performs the client-side escaping exactly once. The
+  HTTP mux normalizes chi path captures exactly once, so services receive
+  decoded values without app-local `url.PathUnescape` calls; literal percent
+  sequences remain literal.
 - `FormRequest()` is for typed object payloads and constructor unions only; incompatible body/param mixes are rejected during design validation instead of silently falling back to app-local parsing.
 - Form-encoded unions keep scalar branches on the canonical wrapper shape (`type` + `value`) but flatten object branches onto normal form fields; direct top-level union form payloads do not add an extra synthetic wrapper key, and all-optional object branches may be selected by discriminator alone without synthetic `value` fields.
 - `MultipartRequest()` now generates server-side decoding for supported object payloads, including common file-plus-fields uploads, instead of requiring a handwritten decoder hook.

--- a/http/codegen/misc_sections.go
+++ b/http/codegen/misc_sections.go
@@ -285,13 +285,13 @@ func renderPathInitCode(args []*InitArgData, pathParams *expr.Object, pathFormat
 func renderPathSliceConversion(dt expr.DataType) string {
 	switch dt.Name() {
 	case "string":
-		return "url.PathEscape(v)"
+		return "v"
 	case "bytes":
-		return "url.PathEscape(string(v))"
+		return "string(v)"
 	default:
 		converted := renderQuerySliceConversion(dt)
 		if strings.HasPrefix(converted, "url.QueryEscape(") {
-			return "url.PathEscape(" + strings.TrimPrefix(converted, "url.QueryEscape(")
+			return strings.TrimSuffix(strings.TrimPrefix(converted, "url.QueryEscape("), ")")
 		}
 		return converted
 	}

--- a/http/codegen/paths.go
+++ b/http/codegen/paths.go
@@ -42,7 +42,6 @@ func pathSections(svc *expr.HTTPServiceExpr, pkg string, services *ServicesData)
 	sections = append(sections,
 		codegen.Header(title, pkg, []*codegen.ImportSpec{
 			{Path: "fmt"},
-			{Path: "net/url"},
 			{Path: "strconv"},
 			{Path: "strings"},
 		}),

--- a/http/codegen/paths_test.go
+++ b/http/codegen/paths_test.go
@@ -45,6 +45,17 @@ func TestPaths(t *testing.T) {
 	}
 }
 
+func TestPathConstructorsLeaveEscapingToURL(t *testing.T) {
+	for _, dsl := range []func(){testdata.PathOneParamDSL, testdata.PathStringSliceParamDSL} {
+		root := RunHTTPDSL(t, dsl)
+		services := CreateHTTPServices(root)
+		sections := serverPath(root.API.HTTP.Services[0], services).AllSections()
+		code := codegen.SectionCode(t, sections[1])
+
+		require.NotContains(t, code, "PathEscape")
+	}
+}
+
 func TestPathTrailingShash(t *testing.T) {
 	cases := []struct {
 		Name string

--- a/http/codegen/server_decode_test.go
+++ b/http/codegen/server_decode_test.go
@@ -1,7 +1,6 @@
 package codegen
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -300,14 +299,13 @@ func TestRequestDecoderMapQueryPresenceIsScopedToMapParam(t *testing.T) {
 	require.NotContains(t, code, "if len(queryRaw) == 0 {")
 }
 
-func TestPathArrayDecodeUnescapesElementsAfterSplit(t *testing.T) {
+func TestPathArrayDecodeUsesMuxNormalizedElements(t *testing.T) {
 	code := decodeSectionCode(t, testdata.PayloadPathArrayStringDSL)
 
 	split := `pRawSlice := strings.Split(pRaw, ",")`
 	unescape := "rvDecoded, err2 := url.PathUnescape(rv)"
 	require.Contains(t, code, split)
-	require.Contains(t, code, unescape)
-	require.Less(t, strings.Index(code, split), strings.Index(code, unescape))
+	require.NotContains(t, code, unescape)
 }
 
 func TestRequestDecoderSkipsMapEntryAfterInvalidKeyParse(t *testing.T) {

--- a/http/codegen/template_sources_multipart_partials.go
+++ b/http/codegen/template_sources_multipart_partials.go
@@ -270,11 +270,6 @@ var multipartRequestDecoderConversionPartials = []templateSource{
 		{{ .VarName }}RawSlice := strings.Split({{ .VarName }}Raw, ",")
 		{{ .VarName }} = make({{ goTypeRef .Type }}, len({{ .VarName }}RawSlice))
 		for i, rv := range {{ .VarName }}RawSlice {
-			rvDecoded, err2 := url.PathUnescape(rv)
-			if err2 != nil {
-				err = loom.MergeErrors(err, loom.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName }}Raw, "path-escaped array"))
-			}
-			rv = rvDecoded
 			{{- template "partial_slice_item_conversion" . }}
 		}
 	{{- else }}

--- a/http/codegen/template_sources_request_decoder_partials.go
+++ b/http/codegen/template_sources_request_decoder_partials.go
@@ -285,11 +285,6 @@ var httpDecoderConversionPartials = []templateSource{
 		{{ .VarName }}RawSlice := strings.Split({{ .VarName }}Raw, ",")
 		{{ .VarName }} = make({{ goTypeRef .Type }}, len({{ .VarName }}RawSlice))
 		for i, rv := range {{ .VarName }}RawSlice {
-			rvDecoded, err2 := url.PathUnescape(rv)
-			if err2 != nil {
-				err = loom.MergeErrors(err, loom.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName }}Raw, "path-escaped array"))
-			}
-			rv = rvDecoded
 			{{- template "partial_slice_item_conversion" . }}
 		}
 	{{- else }}

--- a/http/codegen/testdata/golden/paths_path-with-interface-slice-param.go.golden
+++ b/http/codegen/testdata/golden/paths_path-with-interface-slice-param.go.golden
@@ -2,7 +2,7 @@
 func MethodPathInterfaceSliceParamServicePathInterfaceSliceParamPath(a []any) string {
 	aSlice := make([]string, len(a))
 	for i, v := range a {
-		aSlice[i] = url.PathEscape(fmt.Sprintf("%v", v))
+		aSlice[i] = fmt.Sprintf("%v", v)
 	}
 	return fmt.Sprintf("/one/%v/two", strings.Join(aSlice, ","))
 }

--- a/http/codegen/testdata/golden/paths_path-with-string-slice-param.go.golden
+++ b/http/codegen/testdata/golden/paths_path-with-string-slice-param.go.golden
@@ -2,7 +2,7 @@
 func MethodPathStringSliceParamServicePathStringSliceParamPath(a []string) string {
 	aSlice := make([]string, len(a))
 	for i, v := range a {
-		aSlice[i] = url.PathEscape(v)
+		aSlice[i] = v
 	}
 	return fmt.Sprintf("/one/%v/two", strings.Join(aSlice, ","))
 }

--- a/http/codegen/testdata/golden/server_decode_decode-path-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-array-string-validate.go.golden
@@ -15,11 +15,6 @@ func DecodeMethodPathArrayStringValidateRequest(mux loomhttp.Muxer, _ func(*http
 			pRawSlice := strings.Split(pRaw, ",")
 			p = make([]string, len(pRawSlice))
 			for i, rv := range pRawSlice {
-				rvDecoded, err2 := url.PathUnescape(rv)
-				if err2 != nil {
-					err = loom.MergeErrors(err, loom.InvalidFieldTypeError("p", pRaw, "path-escaped array"))
-				}
-				rv = rvDecoded
 				p[i] = rv
 			}
 		}

--- a/http/codegen/testdata/golden/server_decode_decode-path-array-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-array-string.go.golden
@@ -14,11 +14,6 @@ func DecodeMethodPathArrayStringRequest(mux loomhttp.Muxer, _ func(*http.Request
 			pRawSlice := strings.Split(pRaw, ",")
 			p = make([]string, len(pRawSlice))
 			for i, rv := range pRawSlice {
-				rvDecoded, err2 := url.PathUnescape(rv)
-				if err2 != nil {
-					err = loom.MergeErrors(err, loom.InvalidFieldTypeError("p", pRaw, "path-escaped array"))
-				}
-				rv = rvDecoded
 				p[i] = rv
 			}
 		}

--- a/http/codegen/testdata/golden/server_decode_decode-path-primitive-array-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-primitive-array-bool-validate.go.golden
@@ -15,11 +15,6 @@ func DecodeMethodPathPrimitiveArrayBoolValidateRequest(mux loomhttp.Muxer, _ fun
 			pRawSlice := strings.Split(pRaw, ",")
 			p = make([]bool, len(pRawSlice))
 			for i, rv := range pRawSlice {
-				rvDecoded, err2 := url.PathUnescape(rv)
-				if err2 != nil {
-					err = loom.MergeErrors(err, loom.InvalidFieldTypeError("p", pRaw, "path-escaped array"))
-				}
-				rv = rvDecoded
 				v, err2 := strconv.ParseBool(rv)
 				if err2 != nil {
 					err = loom.MergeErrors(err, loom.InvalidFieldTypeError("p", pRaw, "array of booleans"))

--- a/http/codegen/testdata/golden/server_decode_decode-path-primitive-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-primitive-array-string-validate.go.golden
@@ -15,11 +15,6 @@ func DecodeMethodPathPrimitiveArrayStringValidateRequest(mux loomhttp.Muxer, _ f
 			pRawSlice := strings.Split(pRaw, ",")
 			p = make([]string, len(pRawSlice))
 			for i, rv := range pRawSlice {
-				rvDecoded, err2 := url.PathUnescape(rv)
-				if err2 != nil {
-					err = loom.MergeErrors(err, loom.InvalidFieldTypeError("p", pRaw, "path-escaped array"))
-				}
-				rv = rvDecoded
 				p[i] = rv
 			}
 		}

--- a/http/mux.go
+++ b/http/mux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sync"
 
@@ -163,14 +164,26 @@ func (m *mux) Vars(r *http.Request) map[string]string {
 	}
 	vars := make(map[string]string, len(params.Keys))
 	for i, k := range params.Keys {
+		value := params.Values[i]
+		if r.URL.RawPath != "" {
+			value = unescapePathParam(value)
+		}
 		if k == "*" {
 			wildcard := m.wildcards[r.Method+"::"+ctx.RoutePattern()]
-			vars[wildcard] = params.Values[i]
+			vars[wildcard] = value
 			continue
 		}
-		vars[k] = params.Values[i]
+		vars[k] = value
 	}
 	return vars
+}
+
+func unescapePathParam(value string) string {
+	unescaped, err := url.PathUnescape(value)
+	if err != nil {
+		return value
+	}
+	return unescaped
 }
 
 // Use appends a middleware to the list of middlewares to be applied

--- a/http/mux_test.go
+++ b/http/mux_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,7 +110,7 @@ func TestVars(t *testing.T) {
 			Pattern: "/users/{id}",
 			URL:     "/users/%40123",
 			Expected: map[string]string{
-				"id": "%40123",
+				"id": "@123",
 			},
 		},
 		{
@@ -125,8 +126,16 @@ func TestVars(t *testing.T) {
 			Pattern: "/users/{id}/posts/{*post_id}",
 			URL:     "/users/%40123/posts/456/789%24",
 			Expected: map[string]string{
-				"id":      "%40123",
-				"post_id": "456/789%24",
+				"id":      "@123",
+				"post_id": "456/789$",
+			},
+		},
+		{
+			Name:    "encoded slash uses raw path",
+			Pattern: "/users/{id}",
+			URL:     "/users/hello%2Fworld",
+			Expected: map[string]string{
+				"id": "hello/world",
 			},
 		},
 		{
@@ -149,6 +158,25 @@ func TestVars(t *testing.T) {
 			req, _ := http.NewRequest("GET", c.URL, nil)
 			w := httptest.NewRecorder()
 			mux.ServeHTTP(w, req)
+			assert.True(t, called)
+		})
+	}
+}
+
+func TestVarsRoundTripURLPath(t *testing.T) {
+	cases := []string{"hello world", "100%20"}
+	for _, value := range cases {
+		t.Run(value, func(t *testing.T) {
+			var called bool
+			mux := NewMuxer()
+			mux.Handle(http.MethodGet, "/users/{id}", func(_ http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, value, mux.Vars(r)["id"])
+				called = true
+			})
+
+			u := &url.URL{Path: "/users/" + value}
+			req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+			mux.ServeHTTP(httptest.NewRecorder(), req)
 			assert.True(t, called)
 		})
 	}

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -80,6 +80,9 @@ This roadmap is meant to keep work focused on those outcomes instead of accumula
 - HTTP request decoders now support string-backed custom
   `struct:field:type` path, query, header, and cookie fields through
   `encoding.TextUnmarshaler`.
+- HTTP path parameters now normalize percent encoding exactly once across
+  chi raw-path and canonical-path routing; generated client path constructors
+  leave scalar and array values decoded for `net/url` to escape exactly once.
 - JSON-RPC SSE server generation now emits `message` events for streamed payloads and JSON-RPC error envelopes, while final success envelopes still use `response`; generated SSE clients and the integration harness preserve and validate those event types while remaining backward compatible with legacy/default frames.
 - JSON-RPC SSE server streams now defer committing `200 OK` plus `Content-Type: text/event-stream` until the first SSE frame is actually written, so endpoint setup failures can still surface as the correct HTTP error response. The raw streamable-HTTP `GET /rpc` listener for `events/stream` remains an explicit eager-open exception so clients can observe stream establishment before the first published notification.
 - Mixed JSON-RPC HTTP/SSE servers now inspect the decoded JSON-RPC method before routing `Accept: text/event-stream` requests into SSE handling, so MCP-style `initialize` calls can still return normal JSON while `events/stream` keeps the streamable HTTP behavior.


### PR DESCRIPTION
## Summary
- normalize chi raw-path captures exactly once in the HTTP mux
- leave generated client path values decoded so `net/url` performs escaping once
- remove redundant array path unescaping from generated request decoders
- add scalar, array, encoded-slash, space, and literal-percent regression coverage

## Verification
- `go test ./http/...`
- `make lint`
- `make test`

Closes #129