### PR TITLE
fix(http): return 413 for oversized requests

### DIFF
--- a/.agents/skills/loom/SKILL.md
+++ b/.agents/skills/loom/SKILL.md
@@ -93,6 +93,11 @@ build Auto-K without repeating large amounts of app-local glue.
 - Loom HTTP default errors now use RFC 9457-style
   `application/problem+json` documents with a stable machine-readable `code`
   field instead of the legacy upstream error media type.
+- Built-in HTTP request decoders return status `413` with problem code
+  `request_too_large` when the 32 MiB body limit is exceeded. This applies to
+  generated multipart decoding's aggregate limit as well as JSON, XML, Gob,
+  HTML, and plain-text request bodies; malformed bodies remain
+  `decode_payload` errors.
 - Use `ProblemResult` / `ProblemResultIdentifier` explicitly when you want to
   model that same problem-document contract yourself in custom result/error
   shapes.

--- a/docs/http-guide.md
+++ b/docs/http-guide.md
@@ -378,6 +378,10 @@ Method("create", func() {
 Loom's built-in JSON, XML, Gob, HTML, and plain-text request decoders accept at
 most 32 MiB. Generated multipart decoding uses the same 32 MiB aggregate limit
 across all parts, including unnamed parts; it is not a per-file allowance.
+Requests that exceed either limit receive an RFC 9457
+`application/problem+json` response with status `413` and code
+`request_too_large`, rather than the `decode_payload` response used for
+malformed bodies.
 Generated clients also cap buffered response-body restoration at 32 MiB.
 
 Unexpected response bodies included in generated client errors are capped at

--- a/http/encoding.go
+++ b/http/encoding.go
@@ -87,13 +87,13 @@ func RequestDecoder(r *http.Request) Decoder {
 	}
 	switch contentType {
 	case "application/json":
-		return newLimitedDecoder(r.Body, decodeJSON)
+		return newRequestLimitedDecoder(r.Body, decodeJSON)
 	case "application/gob":
-		return newLimitedDecoder(r.Body, decodeGOB)
+		return newRequestLimitedDecoder(r.Body, decodeGOB)
 	case "application/xml":
-		return newLimitedDecoder(r.Body, decodeXML)
+		return newRequestLimitedDecoder(r.Body, decodeXML)
 	case "text/html", "text/plain":
-		return newTextDecoder(r.Body, contentType)
+		return newRequestTextDecoder(r.Body, contentType)
 	default:
 		return newUnsupportedDecoder(contentType)
 	}
@@ -370,27 +370,37 @@ func (e *textEncoder) Encode(v any) (err error) {
 }
 
 func newTextDecoder(r io.Reader, ct string) Decoder {
-	return &textDecoder{r, ct}
+	return &textDecoder{r: r, ct: ct}
+}
+
+func newRequestTextDecoder(r io.Reader, ct string) Decoder {
+	return &textDecoder{r: r, ct: ct, request: true}
 }
 
 func newLimitedDecoder(r io.Reader, decode func(io.Reader, any) error) Decoder {
 	return &limitedDecoder{r: r, decode: decode}
 }
 
+func newRequestLimitedDecoder(r io.Reader, decode func(io.Reader, any) error) Decoder {
+	return &limitedDecoder{r: r, decode: decode, request: true}
+}
+
 type textDecoder struct {
-	r  io.Reader
-	ct string
+	r       io.Reader
+	ct      string
+	request bool
 }
 
 type limitedDecoder struct {
-	r      io.Reader
-	decode func(io.Reader, any) error
+	r       io.Reader
+	decode  func(io.Reader, any) error
+	request bool
 }
 
 func (d *limitedDecoder) Decode(v any) error {
 	b, err := readAllLimited(d.r, DefaultMaxRequestBodyBytes)
 	if err != nil {
-		return err
+		return requestBodyDecodeError(err, d.request)
 	}
 	return d.decode(bytes.NewReader(b), v)
 }
@@ -398,7 +408,7 @@ func (d *limitedDecoder) Decode(v any) error {
 func (e *textDecoder) Decode(v any) error {
 	b, err := readAllLimited(e.r, DefaultMaxRequestBodyBytes)
 	if err != nil {
-		return err
+		return requestBodyDecodeError(err, e.request)
 	}
 	switch c := v.(type) {
 	case *string:
@@ -433,6 +443,13 @@ func readAllLimited(r io.Reader, limit int64) ([]byte, error) {
 		return nil, errRequestBodyTooLarge
 	}
 	return b, nil
+}
+
+func requestBodyDecodeError(err error, request bool) error {
+	if request && errors.Is(err, errRequestBodyTooLarge) {
+		return loom.RequestBodyTooLargeError()
+	}
+	return err
 }
 
 // newUnsupportedDecoder returns a decoder that returns an error indicating that

--- a/http/encoding_test.go
+++ b/http/encoding_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -357,7 +358,7 @@ func TestRequestDecoderCapsJSONBody(t *testing.T) {
 
 			err := RequestDecoder(req).Decode(&out)
 
-			require.ErrorIs(t, err, errRequestBodyTooLarge)
+			requireRequestBodyTooLargeResponse(t, err)
 			require.Empty(t, out.Value)
 		})
 	}
@@ -496,7 +497,7 @@ func TestTextPlainDecoderCapsBody(t *testing.T) {
 
 	err := decoder.Decode(&value)
 
-	require.ErrorIs(t, err, errRequestBodyTooLarge)
+	requireRequestBodyTooLargeResponse(t, err)
 	require.Empty(t, value)
 }
 
@@ -516,7 +517,7 @@ func TestReadMultipartFormCapsPartData(t *testing.T) {
 
 	form, err := ReadMultipartForm(mr)
 
-	require.ErrorIs(t, err, errRequestBodyTooLarge)
+	requireRequestBodyTooLargeResponse(t, err)
 	require.Nil(t, form)
 }
 
@@ -538,7 +539,7 @@ func TestReadMultipartFormCapsAggregateData(t *testing.T) {
 
 	form, err := ReadMultipartForm(mr)
 
-	require.ErrorIs(t, err, errRequestBodyTooLarge)
+	requireRequestBodyTooLargeResponse(t, err)
 	require.Nil(t, form)
 }
 
@@ -562,8 +563,30 @@ func TestReadMultipartFormCapsNamelessPartData(t *testing.T) {
 
 	form, err := ReadMultipartForm(mr)
 
-	require.ErrorIs(t, err, errRequestBodyTooLarge)
+	requireRequestBodyTooLargeResponse(t, err)
 	require.Nil(t, form)
+}
+
+func requireRequestBodyTooLargeResponse(t *testing.T, err error) {
+	t.Helper()
+
+	var serviceErr *loom.ServiceError
+	require.ErrorAs(t, err, &serviceErr)
+	require.Equal(t, loom.RequestBodyTooLarge, serviceErr.Name)
+
+	w := httptest.NewRecorder()
+	encoder := ErrorEncoder(ResponseEncoder, nil)
+	require.NoError(t, encoder(context.Background(), w, err))
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+	require.Equal(t, ProblemJSONContentType, w.Header().Get("Content-Type"))
+
+	var problem ProblemResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&problem))
+	require.Equal(t, "about:blank", problem.Type)
+	require.Equal(t, http.StatusText(http.StatusRequestEntityTooLarge), problem.Title)
+	require.Equal(t, http.StatusRequestEntityTooLarge, problem.Status)
+	require.Equal(t, "request body too large", problem.Detail)
+	require.Equal(t, loom.RequestBodyTooLarge, problem.Code)
 }
 
 type errReader struct{}

--- a/http/error.go
+++ b/http/error.go
@@ -154,6 +154,9 @@ func (resp *ProblemResponse) StatusCode() int {
 }
 
 func inferProblemStatus(err *loom.ServiceError) int {
+	if err.Name == loom.RequestBodyTooLarge {
+		return http.StatusRequestEntityTooLarge
+	}
 	if err.Name == loom.UnsupportedMediaType {
 		return http.StatusUnsupportedMediaType
 	}
@@ -186,6 +189,8 @@ func isGenericHTTPProblem(code string, status int) bool {
 		return code == "conflict"
 	case http.StatusRequestTimeout:
 		return code == "request_timeout"
+	case http.StatusRequestEntityTooLarge:
+		return code == loom.RequestBodyTooLarge
 	case http.StatusUnsupportedMediaType:
 		return code == loom.UnsupportedMediaType
 	case http.StatusUnprocessableEntity:

--- a/http/multipart.go
+++ b/http/multipart.go
@@ -52,7 +52,7 @@ func ReadMultipartForm(mr *multipart.Reader) (*MultipartForm, error) {
 		if name == "" {
 			data, readErr := readAllLimited(part, remaining)
 			if readErr != nil {
-				return nil, readErr
+				return nil, requestBodyDecodeError(readErr, true)
 			}
 			remaining -= int64(len(data))
 			if closeErr := part.Close(); closeErr != nil {
@@ -61,11 +61,11 @@ func ReadMultipartForm(mr *multipart.Reader) (*MultipartForm, error) {
 			continue
 		}
 		if remaining <= 0 {
-			return nil, errRequestBodyTooLarge
+			return nil, requestBodyDecodeError(errRequestBodyTooLarge, true)
 		}
 		data, readErr := readAllLimited(part, remaining)
 		if readErr != nil {
-			return nil, readErr
+			return nil, requestBodyDecodeError(readErr, true)
 		}
 		closeErr := part.Close()
 		if closeErr != nil {

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -92,6 +92,9 @@ const (
 	UnsupportedMediaType = "unsupported_media_type"
 	// DecodePayload is the error name for decode payload errors.
 	DecodePayload = "decode_payload"
+	// RequestBodyTooLarge is the error name returned by the Loom decoder when
+	// the HTTP request body exceeds the framework limit.
+	RequestBodyTooLarge = "request_too_large"
 	// MissingPayload is the error name for missing payload errors.
 	MissingPayload = "missing_payload"
 )
@@ -152,6 +155,12 @@ func MissingPayloadError() error {
 // body cannot be decoded successfully.
 func DecodePayloadError(msg string) error {
 	return PermanentError(DecodePayload, "%s", msg)
+}
+
+// RequestBodyTooLargeError is the error produced by the Loom decoder when an
+// HTTP request body exceeds the framework limit.
+func RequestBodyTooLargeError() error {
+	return PermanentError(RequestBodyTooLarge, "request body too large")
 }
 
 // UnsupportedMediaTypeError is the error produced by the Loom decoder when the

--- a/pkg/error_test.go
+++ b/pkg/error_test.go
@@ -38,6 +38,21 @@ func TestServiceErrorUsesLoomErrorNameOnly(t *testing.T) {
 	}
 }
 
+func TestRequestBodyTooLargeError(t *testing.T) {
+	err := RequestBodyTooLargeError()
+
+	var serviceErr *ServiceError
+	if !errors.As(err, &serviceErr) {
+		t.Fatalf("got %T, want *ServiceError", err)
+	}
+	if serviceErr.Name != RequestBodyTooLarge {
+		t.Errorf("got name %q, want %q", serviceErr.Name, RequestBodyTooLarge)
+	}
+	if serviceErr.Message != "request body too large" {
+		t.Errorf("got message %q, want request body too large", serviceErr.Message)
+	}
+}
+
 func TestServiceErrorUnwrap(t *testing.T) {
 	var (
 		errFoo          = errors.New("foo")


### PR DESCRIPTION
## Summary

- classify oversized built-in HTTP request bodies as `request_too_large`
- return RFC 9457 problem responses with HTTP 413 for JSON, text, and generated multipart requests
- preserve the existing client-response limiter behavior
- document the request-size wire contract

## Root cause

The shared byte limiter returned a private sentinel. Generated request decoders did not recognize it as a Loom service error, so they wrapped it as `decode_payload`, which defaults to HTTP 400.

## Validation

- `go test ./pkg ./http/... -count=1`
- `make lint`
- `make test`

Closes #180