### PR TITLE
docs: correct Loom DSL guidance

### DIFF
--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -21,6 +21,29 @@ business logic stays in files you own.
 go install github.com/CaliLuke/loom/cmd/loom@latest
 ```
 
+### Pinning the Generator in a Module
+
+Applications that want reproducible generation can record the Loom command as
+a Go tool dependency:
+
+```bash
+go get -tool github.com/CaliLuke/loom/cmd/loom@v1.8.0-alpha.2
+go tool loom gen example.com/myservice/design
+```
+
+This records the command's complete dependency graph in the application's
+`go.mod` and `go.sum`. Installing only the root Loom module does not necessarily
+record command-only dependencies such as the code generator's source-emission
+packages.
+
+For an existing `//go:generate` or script that intentionally uses `go run`, add
+the command package—not only the root module—before invoking it:
+
+```bash
+go get github.com/CaliLuke/loom/cmd/loom@v1.8.0-alpha.2
+go run github.com/CaliLuke/loom/cmd/loom gen example.com/myservice/design
+```
+
 ### Commands
 
 All commands expect Go package import paths, not filesystem paths:

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -991,13 +991,13 @@ through more than one transport:
 
 ```go
 var AccessToken = JWTSecurity("access_token")
-var BrowserSession = APIKeySecurity("browser_session", func() {
-    In("cookie")
-})
+var BrowserSession = APIKeySecurity("browser_session")
 
 var AppSession = SessionAuth("app_session", func() {
     BearerTransport(AccessToken, "auth")
-    CookieTransport(BrowserSession, "browser_session")
+    CookieTransport(BrowserSession, "", func() {
+        CookieName("app_session")
+    })
 })
 
 var _ = Service("accounts", func() {
@@ -1039,7 +1039,28 @@ method.
 Use `AuthErrorResponses()` in HTTP scope to add standard 401/403 error response
 mappings, and use `SessionCookie(...)` in HTTP response scope when setting a
 session cookie with secure defaults: `Path("/")`, `Secure`, `HttpOnly`, and
-`SameSite=Lax`.
+`SameSite=Lax`. To clear that cookie on logout, return an empty value from the
+result field mapped to the cookie and set `CookieMaxAge(-1)`:
+
+```go
+Method("logout", func() {
+    Result(func() {
+        Field(1, "session_token", String)
+        Required("session_token")
+    })
+    HTTP(func() {
+        POST("/logout")
+        Response(StatusNoContent, func() {
+            SessionCookie("session_token:app_session", String)
+            CookieMaxAge(-1)
+        })
+    })
+})
+```
+
+A negative max age instructs browsers to delete the cookie immediately. Zero
+omits the `Max-Age` attribute, while a positive value is its lifetime in
+seconds.
 
 ### CORS
 
@@ -1261,6 +1282,33 @@ Body(func() {
     Attribute("age:a")   // age attribute from "a" field in JSON
 })
 ```
+
+### Response Headers
+
+Declare response headers inside a `Response` block. The mapped attribute comes
+from the method result; result fields not mapped to headers or cookies remain
+in the response body:
+
+```go
+Method("create", func() {
+    Result(func() {
+        Field(1, "href", String, "Canonical account URL")
+        Field(2, "name", String, "Account name")
+        Required("href", "name")
+    })
+    HTTP(func() {
+        POST("/accounts")
+        Response(StatusCreated, func() {
+            Header("href:Location")
+        })
+    })
+})
+```
+
+The mapping syntax is `"result_attribute:HTTP-Header-Name"`. Use
+`Header("href")` when the result attribute name is already the desired HTTP
+header name. Type, description, and validation are inherited from the result
+attribute unless explicitly overridden.
 
 ### Form and Multipart Request Bodies
 
@@ -1561,14 +1609,14 @@ Method("doubly_secure", func() {
 
 ### Implementing Security
 
-Loom generates an `Auther` interface that your service must implement:
+Loom generates an `Authorizer` interface that your service must implement:
 
 ```go
-type Auther interface {
-    BasicAuth(ctx context.Context, user, pass string, scheme *security.BasicScheme) (context.Context, error)
-    JWTAuth(ctx context.Context, token string, scheme *security.JWTScheme) (context.Context, error)
-    APIKeyAuth(ctx context.Context, key string, scheme *security.APIKeyScheme) (context.Context, error)
-    OAuth2Auth(ctx context.Context, token string, scheme *security.OAuth2Scheme) (context.Context, error)
+type Authorizer interface {
+    BasicAuth(ctx context.Context, user, pass string, schema *security.BasicScheme) (context.Context, error)
+    JWTAuth(ctx context.Context, token string, schema *security.JWTScheme) (context.Context, error)
+    APIKeyAuth(ctx context.Context, key string, schema *security.APIKeyScheme) (context.Context, error)
+    OAuth2Auth(ctx context.Context, token string, schema *security.OAuth2Scheme) (context.Context, error)
 }
 ```
 

--- a/dsl/http_cookies.go
+++ b/dsl/http_cookies.go
@@ -97,9 +97,12 @@ func SessionCookie(name string, args ...any) {
 
 // CookieMaxAge defines the "max-age" attribute of a HTTP response cookie.
 //
-// CookieMaxAge must appear in a Cookie expression.
+// CookieMaxAge must appear after Cookie or SessionCookie in a HTTP response
+// expression.
 //
-// CookieMaxAge accepts one argument which is the max-age value.
+// CookieMaxAge accepts one argument which is the max-age value in seconds. A
+// positive value sets the cookie lifetime, zero omits the Max-Age attribute,
+// and a negative value deletes the cookie immediately.
 //
 // Example:
 //
@@ -110,6 +113,10 @@ func SessionCookie(name string, args ...any) {
 //	            Response(StatusCreated, func() {
 //	                Cookie("session:SID", String)
 //	                CookieMaxAge(3600)
+//	            })
+//	            Response(StatusNoContent, func() {
+//	                SessionCookie("expired_session:SID", String)
+//	                CookieMaxAge(-1) // Delete the cookie immediately.
 //	            })
 //	        })
 //	    })

--- a/dsl/response.go
+++ b/dsl/response.go
@@ -61,7 +61,7 @@ import (
 //
 // By default:
 //
-//   - success HTTP responses use code 200 (OK) and error HTTP responses use code 500 (Internal Server Error)
+//   - success HTTP responses use code 200 (OK) and error HTTP responses use code 400 (Bad Request)
 //   - error JSON-RPC responses use code -32603 (Internal error)
 //   - success gRPC responses use code 0 (OK) and error gRPC responses use code 2 (Unknown)
 //   - The result type attributes are all mapped to the HTTP response body,

--- a/scripts/docscheck/main.go
+++ b/scripts/docscheck/main.go
@@ -14,11 +14,12 @@ import (
 )
 
 var (
-	markdownLinkPattern = regexp.MustCompile(`!?\[[^]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)`)
-	headingPattern      = regexp.MustCompile(`^#{1,6}\s+(.+?)\s*#*\s*$`)
-	localCommandPattern = regexp.MustCompile(`\bloom\s+(?:gen|example)\s+\./`)
-	legacyNamingPattern = regexp.MustCompile(`(?:github\.com/goadesign/goa|goa\.design/goa|\bgoa\s+(?:gen|example)\b|\bGOA_[A-Z0-9_]+\b)`)
-	reasonPattern       = regexp.MustCompile(`\bReason\w+\s+Reason\s*=\s*"([^"]+)"`)
+	markdownLinkPattern   = regexp.MustCompile(`!?\[[^]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)`)
+	headingPattern        = regexp.MustCompile(`^#{1,6}\s+(.+?)\s*#*\s*$`)
+	localCommandPattern   = regexp.MustCompile(`\bloom\s+(?:gen|example)\s+\./`)
+	legacyNamingPattern   = regexp.MustCompile(`(?:github\.com/goadesign/goa|goa\.design/goa|\bgoa\s+(?:gen|example)\b|\bGOA_[A-Z0-9_]+\b|\b\x41uther\b)`)
+	unsupportedDSLPattern = regexp.MustCompile(`\bIn\s*\(\s*"cookie"\s*\)`)
+	reasonPattern         = regexp.MustCompile(`\bReason\w+\s+Reason\s*=\s*"([^"]+)"`)
 )
 
 func main() {
@@ -110,6 +111,14 @@ func checkMarkdown(root string, documents []string) []string {
 		for _, match := range legacyNamingPattern.FindAllStringIndex(content, -1) {
 			issues = append(issues, fmt.Sprintf(
 				"%s:%d: legacy upstream naming %q is not allowed in Loom documentation",
+				document,
+				lineNumber(content, match[0]),
+				content[match[0]:match[1]],
+			))
+		}
+		for _, match := range unsupportedDSLPattern.FindAllStringIndex(content, -1) {
+			issues = append(issues, fmt.Sprintf(
+				"%s:%d: unsupported Loom DSL form %q",
 				document,
 				lineNumber(content, match[0]),
 				content[match[0]:match[1]],

--- a/scripts/docscheck/main_test.go
+++ b/scripts/docscheck/main_test.go
@@ -46,6 +46,16 @@ func TestCheckMarkdown(t *testing.T) {
 			content: "Run `goa gen example.com/service/design`.\n",
 			want:    "legacy upstream naming",
 		},
+		{
+			name:    "legacy authorizer name",
+			content: "Implement the `Auth" + "er` interface.\n",
+			want:    "legacy upstream naming",
+		},
+		{
+			name:    "unsupported cookie location",
+			content: "```go\nIn(\"cookie\")\n```\n",
+			want:    "unsupported Loom DSL form",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- replace the nonexistent cookie-location DSL example with CookieTransport and CookieName
- document response headers and session-cookie deletion
- correct the generated Authorizer name and default HTTP error status
- document reproducible module-pinned generator workflows for go tool and go run
- make docs lint reject the stale auth name and unsupported cookie DSL form

## Validation

- focused docs, DSL, and HTTP codegen tests
- make lint
- make test
- clean remote-parity clone verified at 02400485

Closes #174
Closes #175
Closes #176
Closes #177
Closes #181
Closes #185