### PR TITLE
Import Plane's complete OpenAPI transport contract

### DIFF
--- a/.agents/skills/loom-framework/SKILL.md
+++ b/.agents/skills/loom-framework/SKILL.md
@@ -200,12 +200,16 @@ filter, and serialization rules belong here.
   use nullable `anyOf`; reject already-nullable targets because the two
   applicators are not equivalent in that case.
 - Normalize JSON request and success-response `oneOf` object branches to an
-  explicit untagged Loom union when every branch is a flat object with primitive
-  properties. Promote inline branches to deterministic named components,
-  retain the generated sum-type API, and select a decoded branch only after
-  exact JSON-shape and generated value validation succeeds. Reject zero or
-  multiple matches, nested branch fields, and string-encoded transport
-  locations.
+  explicit untagged Loom union when every branch is a flat object whose fields
+  are primitives, concrete named objects, or arrays of either. Promote inline
+  branches to deterministic named components, retain the generated sum-type
+  API, and select a decoded branch only after exact JSON-shape and generated
+  value validation succeeds. Generate every nested named-type validator used
+  by a branch. Reject zero or multiple matches, inline nested object fields,
+  and string-encoded transport locations.
+- Normalize a scalar JSON Schema `const` without a sibling `enum` to a
+  one-member Loom enum. Keep structured constants and combined `const` plus
+  `enum` schemas rejected.
 - Preserve canonical named aliases as OpenAPI components, including aliases of
   `Any`. Preserve the exact source component key even when multiple keys map to
   the same Go identifier. Canonical component identity takes precedence over

--- a/.agents/skills/loom/SKILL.md
+++ b/.agents/skills/loom/SKILL.md
@@ -106,11 +106,17 @@ A two-member `oneOf` with a bare `null` branch and a local `$ref` to a schema
 that explicitly excludes null imports as a nullable named type. Regeneration
 uses the equivalent nullable `anyOf` form. A JSON request or success response
 body `oneOf` with two or more object branches imports as an untagged typed
-union when every branch is a flat object with primitive properties: generated
-Go retains constructors and accessors, JSON uses the bare selected object, and
-decoding requires exactly one fully valid branch. Inline branches become
-deterministic components. Nested branch fields, scalar unions, and untagged
-unions in string-encoded transport locations remain blocked.
+union when every branch is a flat object whose fields are primitives, concrete
+named objects, or arrays of either: generated Go retains constructors and
+accessors, JSON uses the bare selected object, and decoding requires exactly
+one fully valid branch. Inline branches become deterministic components.
+Inline nested objects, scalar unions, and untagged unions in string-encoded
+transport locations remain blocked.
+
+A scalar JSON Schema `const` without a sibling `enum` imports as the equivalent
+one-value `Enum(...)` validation. Regenerated OpenAPI uses `enum` because Loom's
+DSL has no separate scalar-constant construct. Structured constants and schemas
+that combine `const` with `enum` remain blocked.
 
 An OpenAPI free-form object with `type: object` and
 `additionalProperties: true` imports as `MapOf(String, Any)`. Generated Go

--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -102,7 +102,10 @@ func collectErrorTypeSections(svc *Data, svcPath string, addTypeDefSection func(
 			continue
 		}
 		seenErrs[errorType.Name] = struct{}{}
-		maybeAddNamedTypeSection(true, errorType.Name, pathWithDefault(errorType.Loc, svcPath), userTypeSection("error-user-type", errorType), addTypeDefSection, seen)
+		if _, ok := seen[errorType.VarName]; !ok {
+			addTypeDefSection(pathWithDefault(errorType.Loc, svcPath), errorType.Name, userTypeSection("error-user-type", errorType))
+			seen[errorType.VarName] = struct{}{}
+		}
 		errorTypes = append(errorTypes, errorType)
 	}
 	return errorTypes

--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -24,11 +24,13 @@ func Files(genpkg string, service *expr.ServiceExpr, services *ServicesData, use
 	seen := make(map[string]struct{})
 	typeDefSections := make(map[string]map[string]codegen.Section)
 	typesByPath := make(map[string][]string)
+	validationUTF8Paths := make(map[string]bool)
 	svcSections := make([]codegen.Section, 0, 10)
 
 	addTypeDefSection := newTypeSectionCollector(typeDefSections, typesByPath, seen)
 	collectMethodTypeSections(svc, svcPath, addTypeDefSection, seen)
 	collectUserTypeSections(svc, svcPath, addTypeDefSection, seen)
+	collectUntaggedUnionValidationSections(svc, svcPath, addTypeDefSection, seen, validationUTF8Paths)
 	errorTypes := collectErrorTypeSections(svc, svcPath, addTypeDefSection, seen)
 	svcSections = append(svcSections, buildErrorSections(errorTypes, svc, svcPath, addTypeDefSection)...)
 	svcSections = append(svcSections, buildTypeInitSections(svc)...)
@@ -50,6 +52,9 @@ func Files(genpkg string, service *expr.ServiceExpr, services *ServicesData, use
 	if len(svc.unions) > 0 || hasFileResponse(svc.Methods) {
 		imports = append(imports, codegen.LoomNamedImport("http", "loomhttp"))
 	}
+	if validationUTF8Paths[svcPath] {
+		imports = append(imports, codegen.SimpleImport("unicode/utf8"))
+	}
 	header := codegen.Header(service.Name+" service", svc.PkgName, imports)
 	def := serviceDefinitionSection(svc)
 
@@ -57,7 +62,7 @@ func Files(genpkg string, service *expr.ServiceExpr, services *ServicesData, use
 	files = append(files, &codegen.File{Path: svcPath, Sections: buildServiceFileSections(typeDefSections[svcPath], header, def, svcSections)})
 
 	files = append(files, InterceptorsFiles(genpkg, service, services)...)
-	return appendUserTypeFiles(files, svcPath, typeDefSections, typesByPath, userTypePkgs)
+	return appendUserTypeFiles(files, svcPath, typeDefSections, typesByPath, userTypePkgs, validationUTF8Paths)
 }
 
 func newTypeSectionCollector(typeDefSections map[string]map[string]codegen.Section, typesByPath map[string][]string, seen map[string]struct{}) func(string, string, codegen.Section) {
@@ -88,6 +93,25 @@ func collectUserTypeSections(svc *Data, svcPath string, addTypeDefSection func(s
 	}
 	for _, union := range svc.unions {
 		addTypeDefSection(pathWithDefault(union.Loc, svcPath), "~union:"+union.Name, unionTypeSection("service-union-type", union))
+	}
+}
+
+func collectUntaggedUnionValidationSections(svc *Data, svcPath string, addTypeDefSection func(string, string, codegen.Section), seen map[string]struct{}, validationUTF8Paths map[string]bool) {
+	for _, union := range svc.unions {
+		for _, validation := range union.validations {
+			path := pathWithDefault(validation.loc, svcPath)
+			if strings.Contains(validation.data.Validate, "utf8.") {
+				validationUTF8Paths[path] = true
+			}
+			maybeAddNamedTypeSection(
+				true,
+				validation.data.Name,
+				path,
+				validateSection("untagged-union-validation", validation.data),
+				addTypeDefSection,
+				seen,
+			)
+		}
 	}
 }
 
@@ -162,7 +186,7 @@ func buildServiceFileSections(typeSections map[string]codegen.Section, header, d
 	return append(sections, svcSections...)
 }
 
-func appendUserTypeFiles(files []*codegen.File, svcPath string, typeDefSections map[string]map[string]codegen.Section, typesByPath map[string][]string, userTypePkgs map[string][]string) []*codegen.File {
+func appendUserTypeFiles(files []*codegen.File, svcPath string, typeDefSections map[string]map[string]codegen.Section, typesByPath map[string][]string, userTypePkgs map[string][]string, validationUTF8Paths map[string]bool) []*codegen.File {
 	paths := sortedTypePaths(typesByPath)
 	for _, path := range paths {
 		if path == svcPath {
@@ -172,7 +196,7 @@ func appendUserTypeFiles(files []*codegen.File, svcPath string, typeDefSections 
 		if len(sections) == 0 {
 			continue
 		}
-		files = append(files, newUserTypeFile(path, sections, hasUnion))
+		files = append(files, newUserTypeFile(path, sections, hasUnion, validationUTF8Paths[path]))
 	}
 	return files
 }
@@ -204,7 +228,7 @@ func collectUserTypeFileSections(path string, typeNames []string, typeSections m
 	return sections, hasUnion
 }
 
-func newUserTypeFile(path string, sections []codegen.Section, hasUnion bool) *codegen.File {
+func newUserTypeFile(path string, sections []codegen.Section, hasUnion, needsUTF8 bool) *codegen.File {
 	fullRelPath := filepath.Join(codegen.Gendir, path)
 	dir, _ := filepath.Split(fullRelPath)
 	imports := []*codegen.ImportSpec{
@@ -217,6 +241,9 @@ func newUserTypeFile(path string, sections []codegen.Section, hasUnion bool) *co
 			codegen.SimpleImport("net/url"),
 			codegen.LoomNamedImport("http", "loomhttp"),
 		)
+	}
+	if needsUTF8 {
+		imports = append(imports, codegen.SimpleImport("unicode/utf8"))
 	}
 	header := codegen.Header("User types", codegen.Goify(filepath.Base(dir), false), imports)
 	return &codegen.File{Path: fullRelPath, Sections: append([]codegen.Section{header}, sections...)}

--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -461,6 +461,7 @@ type (
 		// HasScalarFormBranch is true when at least one branch keeps canonical
 		// type/value form encoding.
 		HasScalarFormBranch bool
+		validations         []*unionValidationData
 	}
 
 	// UnionFieldData describes a single branch of a union.
@@ -503,6 +504,11 @@ type (
 		PrimitiveAliasType string
 		// TypeTag is the JSON "type" discriminator value for this branch.
 		TypeTag string
+	}
+
+	unionValidationData struct {
+		data *ValidateData
+		loc  *codegen.Location
 	}
 )
 

--- a/codegen/service/service_data_types.go
+++ b/codegen/service/service_data_types.go
@@ -195,6 +195,7 @@ func buildUnionTypeData(u *expr.Union, scope *codegen.NameScope, loc *codegen.Lo
 		ValueKey:            u.GetValueKey(),
 		Untagged:            u.Untagged,
 		HasScalarFormBranch: hasScalarFormBranch,
+		validations:         buildUntaggedUnionValidations(u, scope, loc),
 	}
 }
 
@@ -249,6 +250,29 @@ func buildViewUnionTypeData(u *expr.Union, scope *codegen.NameScope, loc *codege
 func unionBranchValidationCode(att *expr.AttributeExpr, scope *codegen.NameScope) string {
 	ut := att.Type.(expr.UserType)
 	return codegen.ValidationCode(ut.Attribute(), ut, typeContext(scope), true, false, false, "v")
+}
+
+func buildUntaggedUnionValidations(union *expr.Union, scope *codegen.NameScope, loc *codegen.Location) []*unionValidationData {
+	if !union.Untagged {
+		return nil
+	}
+	types := collectTypes(&expr.AttributeExpr{Type: union}, scope, make(map[string]struct{}), loc)
+	validations := make([]*unionValidationData, 0, len(types))
+	for _, data := range types {
+		if !expr.IsObject(data.Type) || expr.IsAlias(data.Type) {
+			continue
+		}
+		validations = append(validations, &unionValidationData{
+			data: &ValidateData{
+				Name:        "Validate" + data.VarName,
+				Ref:         data.Ref,
+				Description: "runs the validations defined on " + data.VarName + ".",
+				Validate:    codegen.ValidationCode(data.Type.Attribute(), data.Type, typeContext(scope), true, false, false, "result"),
+			},
+			loc: data.Loc,
+		})
+	}
+	return validations
 }
 
 func unionBranchJSONFields(att *expr.AttributeExpr) ([]string, []string, []string, bool) {

--- a/codegen/service/service_dedup_test.go
+++ b/codegen/service/service_dedup_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/CaliLuke/loom/codegen"
 	stest "github.com/CaliLuke/loom/codegen/service/testdata"
+	"github.com/CaliLuke/loom/dsl"
 )
 
 // TestService_DedupEventMarkers verifies that when multiple streaming methods share the
@@ -32,4 +33,30 @@ func TestService_DedupEventMarkers(t *testing.T) {
 	// The marker has the shape: func (*SharedEvent) isdupStreamServiceEvent() {}
 	occurrences := strings.Count(code, "func (*SharedEvent) isdupStreamServiceEvent()")
 	require.Equal(t, 1, occurrences, "expected a single event marker for SharedEvent, got %d", occurrences)
+}
+
+func TestServiceDeduplicatesSharedSuccessAndErrorTypeByGoName(t *testing.T) {
+	root := codegen.RunDSL(t, func() {
+		var response = dsl.Type("PlaneApiSerializersModuleModuleserializerResponse", func() {
+			dsl.Attribute("name", dsl.String)
+		})
+
+		dsl.Service("modules", func() {
+			dsl.Method("create", func() {
+				dsl.Result(response)
+			})
+			dsl.Method("update", func() {
+				dsl.Result(response)
+				dsl.Error("invalid", response)
+			})
+		})
+	})
+	services := NewServicesData(root)
+	files := Files("github.com/CaliLuke/loom/example", root.Services[0], services, make(map[string][]string))
+
+	buf := new(bytes.Buffer)
+	for _, section := range files[0].AllSections()[1:] {
+		require.NoError(t, section.Write(buf))
+	}
+	require.Equal(t, 1, strings.Count(buf.String(), "type PlaneAPISerializersModuleModuleserializerResponse struct"))
 }

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -161,11 +161,16 @@ reference imports as the same nullable named type when the referenced schema
 explicitly excludes null. Regenerated OpenAPI uses the equivalent `anyOf`
 representation. A `oneOf` of two or more object schemas in a JSON request or
 success response body imports as an untagged typed union when every branch is a
-flat object with primitive properties. Inline branches become deterministic
-named components, generated Go retains sum-type constructors and accessors, and
-JSON decoding requires exactly one fully valid branch. Nested branch fields,
-scalar unions, discriminated source unions, declared error unions, and untagged
-unions in string-encoded transport locations remain strict import errors.
+flat object whose fields are primitives, concrete named objects, or arrays of
+either. Inline branches become deterministic named components, generated Go
+retains sum-type constructors and accessors, and JSON decoding requires exactly
+one fully valid branch. Inline nested objects, scalar unions, discriminated
+source unions, declared error unions, and untagged unions in string-encoded
+transport locations remain strict import errors.
+
+A scalar JSON Schema `const` without a sibling `enum` imports as an equivalent
+one-member enum. Regenerated OpenAPI emits `enum`. Structured constants and
+schemas that combine `const` with `enum` remain strict import errors.
 
 An unconstrained schema `{}` imports as Loom `Any`. This applies to component
 schemas, object properties, array items, request bodies, and responses. The

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -186,12 +186,13 @@ Generated Go keeps the same sum-type constructors, `Kind`, and `As...`
 accessors. JSON marshaling emits only the selected branch object. Decoding
 validates every candidate and succeeds only when exactly one branch matches.
 Untagged branches must be concrete named flat object types whose fields are
-primitive or primitive aliases. This strict boundary lets decoding preserve
-case-sensitive JSON member names, nullability, required fields, and explicitly
-closed objects before it applies normal Loom value validation. Nested object,
-array, map, and union fields are rejected. OpenAPI renders branch component
-references directly under `oneOf` and omits the discriminator. This encoding
-is for JSON bodies; string-encoded parameters, headers, cookies, forms, and
+primitive values, concrete named objects, or arrays of either. This strict
+boundary lets decoding preserve case-sensitive JSON member names, nullability,
+required fields, and explicitly closed objects before it applies normal Loom
+value validation, including validation in nested named objects. Inline nested
+objects, maps, and union fields are rejected. OpenAPI renders branch component
+references directly under `oneOf` and omits the discriminator. This encoding is
+for JSON bodies; string-encoded parameters, headers, cookies, forms, and
 multipart bodies do not support it.
 
 #### Result View Requiredness

--- a/docs/openapi-import-coverage.md
+++ b/docs/openapi-import-coverage.md
@@ -103,12 +103,15 @@ The following constructs are conditional:
 - A two-member `oneOf` containing one bare `null` schema and one local `$ref`
   maps to a nullable named alias when the referenced schema explicitly excludes
   null. Regeneration uses the equivalent nullable `anyOf` form.
+- A scalar `const` without a sibling `enum` maps to a one-member enum.
+  Regeneration uses the semantically equivalent `enum` representation.
 - A `oneOf` containing two or more object branches in a JSON request or success
   response body maps to an untagged typed union when every branch is a flat
-  object with primitive properties. Inline object branches are promoted to
-  deterministic components. Generated decoding validates exact JSON member
-  names, presence, nullability, closed-object membership, and Loom value
-  constraints for every branch, then accepts exactly one match.
+  object whose fields are primitives, concrete named objects, or arrays of
+  either. Inline object branches are promoted to deterministic components.
+  Generated decoding validates exact JSON member names, presence, nullability,
+  closed-object membership, and nested Loom value constraints for every branch,
+  then accepts exactly one match.
 - `additionalProperties: true` maps to `map[string]any` only when the object
   has no declared properties.
 - A form request whose object has only schema-valued `additionalProperties`
@@ -127,10 +130,13 @@ Loom rejects other composition and structural keywords, including unsupported
 `oneOf` locations or branch shapes, unsupported `anyOf` and `allOf` forms,
 `not`, tuple and contains constraints,
 conditional schemas, dependent schemas, pattern properties, unevaluated
-constraints, property-count constraints, `const`, `multipleOf`,
+constraints, property-count constraints, `multipleOf`,
 `uniqueItems`, content annotations, XML, schema external documentation,
 discriminators, schema dialect controls, anchors, dynamic references, and
 local definitions.
+
+Structured `const` values and schemas that combine `const` with `enum` are also
+rejected.
 
 A Schema Object with `$ref` siblings is rejected. Use a supported `allOf`
 shape when the sibling constraint must remain part of the contract.

--- a/dsl/oneof_test.go
+++ b/dsl/oneof_test.go
@@ -225,7 +225,30 @@ func TestUntaggedRejectsNestedBranchFields(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), `untagged OneOf branch "NestedUntagged" field "child" must be primitive`)
+	require.Contains(t, err.Error(), `untagged OneOf branch "NestedUntagged" field "child" must be primitive, a concrete named object type, or an array of either`)
+}
+
+func TestUntaggedAcceptsNamedObjectBranchFieldsAndArrays(t *testing.T) {
+	root := expr.RunDSL(t, func() {
+		child := Type("NamedUntaggedChild", func() {
+			Attribute("value", String)
+		})
+		first := Type("NamedUntaggedFirst", func() {
+			Attribute("child", child)
+		})
+		second := Type("NamedUntaggedSecond", func() {
+			Attribute("children", ArrayOf(child))
+		})
+		Service("untagged", func() {
+			Method("show", func() {
+				Result(OneOf(first, second), func() {
+					Untagged()
+				})
+			})
+		})
+	})
+
+	require.NotNil(t, root.Service("untagged"))
 }
 
 func TestUntaggedRejectsAmbiguousJSONFieldMetadata(t *testing.T) {

--- a/expr/attribute_validate.go
+++ b/expr/attribute_validate.go
@@ -292,8 +292,8 @@ func (a *AttributeExpr) validateChildTypes(ctx string, parent eval.Expression) *
 				}
 				wireNames := make(map[string]struct{})
 				for _, field := range *AsObject(userType) {
-					if !IsPrimitive(field.Attribute.Type) {
-						verr.Add(parent, "%suntagged OneOf branch %q field %q must be primitive", ctx, branch.Name, field.Name)
+					if !isUntaggedBranchFieldType(field.Attribute.Type) {
+						verr.Add(parent, "%suntagged OneOf branch %q field %q must be primitive, a concrete named object type, or an array of either", ctx, branch.Name, field.Name)
 					}
 					wireName := untaggedJSONFieldName(field.Name, field.Attribute)
 					if wireName == "" {
@@ -316,6 +316,17 @@ func (a *AttributeExpr) validateChildTypes(ctx string, parent eval.Expression) *
 		}
 	}
 	return verr
+}
+
+func isUntaggedBranchFieldType(dataType DataType) bool {
+	if IsPrimitive(dataType) {
+		return true
+	}
+	if userType, named := dataType.(UserType); named {
+		return !IsAlias(userType) && IsObject(userType)
+	}
+	array := AsArray(dataType)
+	return array != nil && isUntaggedBranchFieldType(array.ElemType.Type)
 }
 
 func untaggedJSONFieldName(name string, attribute *AttributeExpr) string {

--- a/internal/openapiimport/analyze.go
+++ b/internal/openapiimport/analyze.go
@@ -623,6 +623,23 @@ func (a *analyzer) schemaEnum(schema *Schema, source *base.Schema, path string) 
 		}
 		schema.Enum = append(schema.Enum, decoded)
 	}
+	if source.Const == nil {
+		return
+	}
+	if len(source.Enum) > 0 {
+		a.unsupported("schema-const", path+"/const", "const combined with enum is not in the strict import subset")
+		return
+	}
+	var decoded any
+	if err := source.Const.Decode(&decoded); err != nil {
+		a.unsupported("schema-const", path+"/const", fmt.Sprintf("const value cannot be decoded: %v", err))
+		return
+	}
+	if _, err := scalarLiteral(decoded); err != nil {
+		a.unsupported("schema-const", path+"/const", err.Error())
+		return
+	}
+	schema.Enum = append(schema.Enum, decoded)
 }
 
 func (a *analyzer) schemaExclusiveBounds(schema *Schema, source *base.Schema) {

--- a/internal/openapiimport/analyze_schema_grammar.go
+++ b/internal/openapiimport/analyze_schema_grammar.go
@@ -66,7 +66,6 @@ func (a *analyzer) schemaUnsupportedKeywords(
 		a.unsupported("advanced-schema", path, "advanced JSON Schema applicators are not in the strict import subset")
 	}
 	if source.MultipleOf != nil || source.UniqueItems != nil || source.MaxProperties != nil || source.MinProperties != nil ||
-		source.Const != nil ||
 		source.ContentEncoding != "" || source.ContentMediaType != "" || source.XML != nil || source.ExternalDocs != nil {
 		a.unsupported("schema-keyword", path, "one or more schema keywords are not in the strict import subset")
 	}

--- a/internal/openapiimport/analyze_test.go
+++ b/internal/openapiimport/analyze_test.go
@@ -35,6 +35,18 @@ func TestAnalyzeJSONYAMLParity(t *testing.T) {
 	require.Len(t, yamlDocument.Operations[2].Parameters, 3)
 	require.Equal(t, "#/components/parameters/PetID", yamlDocument.Operations[2].Parameters[0].Ref)
 	require.Equal(t, "#/components/schemas/Pet", yamlDocument.Operations[2].Responses[0].Response.Schema.Ref)
+	for _, named := range yamlDocument.Components.Schemas {
+		if named.Name != "NewPet" {
+			continue
+		}
+		for _, property := range named.Schema.Properties {
+			if property.Name == "active" {
+				require.Equal(t, []any{true}, property.Schema.Enum)
+				return
+			}
+		}
+	}
+	t.Fatal("NewPet.active schema was not imported")
 }
 
 func TestAnalyzeSupportsAPIKeySecurityContracts(t *testing.T) {

--- a/internal/openapiimport/grammar_coverage_test.go
+++ b/internal/openapiimport/grammar_coverage_test.go
@@ -87,7 +87,6 @@ func TestSchemaGrammarKeywordsAreNeverSilentlyIgnored(t *testing.T) {
 		"$id":                   `$id: 'https://example.com/subject'`,
 		"$schema":               `$schema: 'https://json-schema.org/draft/2020-12/schema'`,
 		"$vocabulary":           `$vocabulary: {'https://json-schema.org/draft/2020-12/vocab/core': true}`,
-		"const":                 `const: fixed`,
 		"contains":              `contains: {type: string}`,
 		"contentEncoding":       `contentEncoding: base64`,
 		"contentMediaType":      `contentMediaType: application/json`,
@@ -583,8 +582,8 @@ func openAPIGrammarCoverage() []grammarObjectCoverage {
 			model: base.Schema{},
 			groups: []grammarFieldGroup{
 				group(grammarPreserved, "analyzer.schema normalization", "ExclusiveMaximum", "ExclusiveMinimum", "Properties", "Title", "Maximum", "Minimum", "MaxLength", "MinLength", "Pattern", "MaxItems", "MinItems", "Required", "Description", "Nullable", "ReadOnly", "WriteOnly", "Deprecated", "Extensions"),
-				group(grammarConditional, "schema normalization and render planning", "Type", "AllOf", "AnyOf", "OneOf", "Examples", "Items", "Format", "Enum", "AdditionalProperties", "Default", "Example"),
-				group(grammarRejected, "schemaUnsupportedKeywords", "SchemaTypeRef", "Discriminator", "PrefixItems", "Contains", "MinContains", "MaxContains", "If", "Else", "Then", "DependentSchemas", "DependentRequired", "PatternProperties", "Defs", "PropertyNames", "UnevaluatedItems", "UnevaluatedProperties", "Id", "Anchor", "DynamicAnchor", "DynamicRef", "Comment", "ContentSchema", "Vocabulary", "Not", "MultipleOf", "UniqueItems", "MaxProperties", "MinProperties", "ContentEncoding", "ContentMediaType", "Const", "XML", "ExternalDocs"),
+				group(grammarConditional, "schema normalization and render planning", "Type", "AllOf", "AnyOf", "OneOf", "Examples", "Items", "Format", "Enum", "Const", "AdditionalProperties", "Default", "Example"),
+				group(grammarRejected, "schemaUnsupportedKeywords", "SchemaTypeRef", "Discriminator", "PrefixItems", "Contains", "MinContains", "MaxContains", "If", "Else", "Then", "DependentSchemas", "DependentRequired", "PatternProperties", "Defs", "PropertyNames", "UnevaluatedItems", "UnevaluatedProperties", "Id", "Anchor", "DynamicAnchor", "DynamicRef", "Comment", "ContentSchema", "Vocabulary", "Not", "MultipleOf", "UniqueItems", "MaxProperties", "MinProperties", "ContentEncoding", "ContentMediaType", "XML", "ExternalDocs"),
 				group(grammarLibrary, "libopenapi schema proxy state", "ParentProxy"),
 			},
 		},

--- a/internal/openapiimport/issue_302_test.go
+++ b/internal/openapiimport/issue_302_test.go
@@ -100,6 +100,113 @@ paths:
 	require.Equal(t, map[string]any{"error": "failed"}, examples[0].Value)
 }
 
+func TestUntaggedOneOfSupportsScalarConstantsAndNamedObjectFields(t *testing.T) {
+	source := []byte(`openapi: 3.1.0
+info: {title: Asset result, version: '1'}
+paths:
+  /assets:
+    get:
+      operationId: getAsset
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    additionalProperties: false
+                    required: [data, status]
+                    properties:
+                      data: {$ref: '#/components/schemas/Asset'}
+                      status: {type: boolean, const: true}
+                  - type: object
+                    additionalProperties: false
+                    required: [error, status]
+                    properties:
+                      error: {type: string}
+                      status: {type: boolean, const: false}
+components:
+  schemas:
+    Asset:
+      type: object
+      required: [id]
+      properties:
+        id: {type: string, format: uuid}
+`)
+
+	document, diagnostics, err := Analyze(source)
+	require.NoError(t, err)
+	require.Empty(t, diagnostics)
+	rendered, err := Render(document, Options{PackageName: "design"})
+	require.NoError(t, err)
+	design := string(rendered)
+	require.Contains(t, design, `Attribute("data", ImportedAsset)`)
+	require.Contains(t, design, "Enum(true)")
+	require.Contains(t, design, "Enum(false)")
+
+	moduleDir := requireRenderedDesignGenerates(t, rendered)
+	requireNestedUntaggedUnionRuntime(t, moduleDir)
+	contract := readGeneratedOpenAPIContract(t, moduleDir)
+	operation := operationFromImportedSpec(t, contract, "/assets", "get")
+	response := operation["responses"].(map[string]any)["200"].(map[string]any)
+	schema := response["content"].(map[string]any)["application/json"].(map[string]any)["schema"].(map[string]any)
+	branches := schema["oneOf"].([]any)
+	success := referencedSchema(t, contract, branches[0].(map[string]any)["$ref"].(string))
+	properties := success["properties"].(map[string]any)
+	require.Equal(t, "#/components/schemas/Asset", properties["data"].(map[string]any)["$ref"])
+	require.Equal(t, []any{true}, properties["status"].(map[string]any)["enum"])
+}
+
+func requireNestedUntaggedUnionRuntime(t *testing.T, moduleDir string) {
+	t.Helper()
+	serviceDir := filepath.Join(moduleDir, "gen", "asset_result")
+	testSource := []byte(`package assetresult
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNestedUntaggedUnionRuntime(t *testing.T) {
+	var result GetAssetResponseDataOrGetAssetResponseError
+	if err := json.Unmarshal([]byte("{\"data\":{\"id\":\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\"},\"status\":true}"), &result); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := result.AsGetAssetResponseData(); !ok {
+		t.Fatalf("decoded result: %#v", result)
+	}
+	if err := json.Unmarshal([]byte("{\"data\":{\"id\":\"not-a-uuid\"},\"status\":true}"), &result); err == nil {
+		t.Fatal("invalid nested object unexpectedly matched")
+	}
+	if err := json.Unmarshal([]byte("{\"data\":{\"id\":\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\"},\"status\":false}"), &result); err == nil {
+		t.Fatal("invalid scalar constant unexpectedly matched")
+	}
+}
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(serviceDir, "nested_untagged_runtime_test.go"), testSource, 0o600))
+	command := exec.Command("go", "test", "-mod=mod", "./gen/asset_result")
+	command.Dir = moduleDir
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+}
+
+func TestScalarConstKeepsUnrepresentableShapesRejected(t *testing.T) {
+	tests := map[string]string{
+		"combined with enum": "type: string\n                const: fixed\n                enum: [fixed]",
+		"structured value":   "type: object\n                const: {id: fixed}",
+	}
+	for name, schema := range tests {
+		t.Run(name, func(t *testing.T) {
+			source := []byte("openapi: 3.1.0\ninfo: {title: Const, version: '1'}\npaths:\n  /value:\n    get:\n      operationId: getValue\n      responses:\n        '200':\n          description: OK\n          content:\n            application/json:\n              schema:\n                " + schema + "\n")
+
+			_, diagnostics, err := Analyze(source)
+			require.NoError(t, err)
+			requireDiagnosticCode(t, diagnostics, "schema-const")
+		})
+	}
+}
+
 func TestNestedNamedUntaggedUnionGeneratesCompilableHTTPTypes(t *testing.T) {
 	source := []byte(`openapi: 3.1.0
 info: {title: Nested Commands, version: '1'}

--- a/internal/openapiimport/plan.go
+++ b/internal/openapiimport/plan.go
@@ -365,8 +365,8 @@ func (p *documentPlanner) schema(schema *Schema, path string) {
 				p.unsupported("schema-oneof-branch", fmt.Sprintf("%s/oneOf/%d", path, index), "untagged oneOf branches must reference concrete object components")
 				continue
 			}
-			if !p.schemaIsFlatPrimitiveObject(named.Schema) {
-				p.unsupported("schema-oneof-branch", fmt.Sprintf("%s/oneOf/%d", path, index), "untagged oneOf branches must be flat objects with primitive properties")
+			if !p.schemaIsFlatUntaggedObject(named.Schema) {
+				p.unsupported("schema-oneof-branch", fmt.Sprintf("%s/oneOf/%d", path, index), "untagged oneOf branches must be flat objects with primitive or named object properties, or arrays of either")
 			}
 		}
 	}
@@ -380,7 +380,7 @@ func (p *documentPlanner) schema(schema *Schema, path string) {
 	}
 }
 
-func (p *documentPlanner) schemaIsFlatPrimitiveObject(schema *Schema) bool {
+func (p *documentPlanner) schemaIsFlatUntaggedObject(schema *Schema) bool {
 	if schema == nil || schema.Type != "object" || len(schema.Bases) > 0 || schema.Items != nil || len(schema.OneOf) > 0 {
 		return false
 	}
@@ -388,11 +388,39 @@ func (p *documentPlanner) schemaIsFlatPrimitiveObject(schema *Schema) bool {
 		return false
 	}
 	for _, property := range schema.Properties {
-		if !p.schemaIsPrimitive(property.Schema, make(map[string]struct{})) {
+		if !p.schemaIsUntaggedProperty(property.Schema, make(map[string]struct{})) {
 			return false
 		}
 	}
 	return true
+}
+
+func (p *documentPlanner) schemaIsUntaggedProperty(schema *Schema, seen map[string]struct{}) bool {
+	if schema == nil || schema.Ref == "" {
+		if schema != nil && schema.Type == "array" && schema.Items != nil {
+			return p.schemaIsUntaggedProperty(schema.Items, seen)
+		}
+		return p.schemaIsPrimitive(schema, seen)
+	}
+	name := strings.TrimPrefix(schema.Ref, "#/components/schemas/")
+	if name == schema.Ref {
+		return false
+	}
+	if _, ok := seen[name]; ok {
+		return false
+	}
+	seen[name] = struct{}{}
+	named, ok := p.schemas[name]
+	if !ok || named.Schema == nil {
+		return false
+	}
+	if named.Schema.Ref != "" {
+		return p.schemaIsUntaggedProperty(named.Schema, seen)
+	}
+	if named.Schema.Type == "object" && len(named.Schema.Bases) == 0 && len(named.Schema.OneOf) == 0 && named.Schema.Items == nil && named.Schema.AdditionalProperties == nil {
+		return true
+	}
+	return p.schemaIsPrimitive(named.Schema, seen)
 }
 
 func (p *documentPlanner) schemaIsPrimitive(schema *Schema, seen map[string]struct{}) bool {

--- a/internal/openapiimport/testdata/supported.json
+++ b/internal/openapiimport/testdata/supported.json
@@ -107,7 +107,8 @@
         "type": "object",
         "properties": {
           "name": {"type": "string", "minLength": 1, "maxLength": 80},
-          "kind": {"type": "string", "enum": ["cat", "dog"], "default": "cat"}
+          "kind": {"type": "string", "enum": ["cat", "dog"], "default": "cat"},
+          "active": {"type": "boolean", "const": true}
         },
         "required": ["name"],
         "additionalProperties": false

--- a/internal/openapiimport/testdata/supported.yaml
+++ b/internal/openapiimport/testdata/supported.yaml
@@ -89,6 +89,9 @@ components:
           type: string
           enum: [cat, dog]
           default: cat
+        active:
+          type: boolean
+          const: true
       required: [name]
       additionalProperties: false
     Pet:


### PR DESCRIPTION
## Summary

- deduplicate shared success and error service types by generated Go identity
- import scalar JSON Schema constants as one-value enums
- support named objects and arrays in untagged object-union branches
- generate nested validators required by untagged-union decoding

## Plane proof

Plane’s 639-operation migration contract imports without skipped operations, generates successfully, and every generated package compiles.

Closes #306.